### PR TITLE
Missed change event on clearTarget

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -90,6 +90,7 @@
     this.$target.val('')
     this.$container.removeClass('combobox-selected')
     this.selected = false
+    this.$target.trigger('change')
   }
 
   , refresh: function () {


### PR DESCRIPTION
I think this should be added since clearTarget clears $target's value.
I found this very useful for resetting dependent comboboxes through events.
