### PR TITLE
Bug fix for my last pull request...

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -75,8 +75,8 @@
 
   , toggle: function () {
     if (this.$container.hasClass('combobox-selected')) {
-      this.$element.val('').focus()
       this.clearTarget()
+      this.$element.val('').focus()
     } else {
       if (this.shown) {
         this.hide()


### PR DESCRIPTION
I noticed a bug introduced with my previous pull request, and I do not want to add any inhibitions to such a great repo! Here is a proposed bug fix.

The bug is seen for any dependent combobox cleared via a change event of it's parent. i.e. Since my parent has changed, I need to clear, now I have focus.
Focus should be set after the change event is triggered within clearTarget to ensure that the currently toggled (and being cleared) combobox retains focus _after_ being cleared.
I haven't delve into this too thoroughly but, if you think there is a better solution to my original pull or to this new bug, I would have no problem with you rolling back past my previous pull.
