### PR TITLE
Add missing semicolon at end of file

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -219,4 +219,4 @@
 
   $.fn.combobox.Constructor = Combobox
 
-}( window.jQuery )
+}( window.jQuery );


### PR DESCRIPTION
The intent of the change is to allow the concatenation of this file with other scripts to produce a combined library.

Without the semicolon, the following code fails to parse correctly and produces an error when the combined script is loaded.

This pull request is related to  Issue #38.
