### PR TITLE
Added call to refresh() inside keyup default

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -174,6 +174,7 @@
 
         default:
           this.clearTarget()
+          this.refresh()
           this.lookup()
       }
 


### PR DESCRIPTION
With the extra call to `refresh()` on keyup `default`, combobox can accomodate situations where the target `select` element's `options` change, such as the result of an ajax call.
