### PR TITLE
fix button height issue

### DIFF
--- a/css/bootstrap-combobox.css
+++ b/css/bootstrap-combobox.css
@@ -26,14 +26,13 @@
 }
 .combobox-container .add-on {
   float: left;
-  display: block;
+  display: inline-block;
   width: auto;
   min-width: 16px;
-  height: 18px;
+  height: inherit !important;
   margin-right: -1px;
   padding: 4px 5px;
   font-weight: normal;
-  line-height: 18px;
   color: #999999;
   text-align: center;
   text-shadow: 0 1px 0 #ffffff;
@@ -42,6 +41,7 @@
   -webkit-border-radius: 3px 0 0 3px;
   -moz-border-radius: 3px 0 0 3px;
   border-radius: 3px 0 0 3px;
+  
 }
 .combobox-container .active {
   background-color: #a9dba9;
@@ -144,4 +144,7 @@
 }
 .control-group.success .combobox-container .caret {
   border-top-color: #468847;
+}
+.btn .combobox-clear [class^="icon-"] {
+  line-height: 1.4em;
 }


### PR DESCRIPTION
Fixed issue where the X and down arrow button height is shorter than the input box.  Also slightly adjust the X box down so that it's vertically centered.

Tested on Chrome, Safari and IE 9
# BEFORE

![height](https://f.cloud.github.com/assets/313176/5175/99973c60-4356-11e2-972b-5d55bd7b1d46.png)
# AFTER

![Screen Shot 2012-12-10 at 11 51 03 PM](https://f.cloud.github.com/assets/313176/5176/d18f43c4-4356-11e2-9849-270b31ac536f.png)
