### PR TITLE
Removing "name" attribute from source element after transfer, to stop a form passing the attribute twice - once empty.

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -80,6 +80,7 @@
     this.options.placeholder = this.$source.attr('data-placeholder') || this.options.placeholder
     this.$element.attr('placeholder', this.options.placeholder)
     this.$target.prop('name', this.$source.prop('name'))
+    this.$source.removeAttr('name')  // Remove from source otherwise form will pass parameter twice.
     this.$element.attr('required', this.$source.attr('required'))
     this.$element.attr('rel', this.$source.attr('rel'))
     this.$element.attr('title', this.$source.attr('title'))


### PR DESCRIPTION
The above caused problems handling inputs in web.py, hence this fix.
