### PR TITLE
Initial value of select is lost if no selection is made

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -80,7 +80,7 @@
     this.options.placeholder = this.$source.attr('data-placeholder') || this.options.placeholder
     this.$element.attr('placeholder', this.options.placeholder)
     this.$target.prop('name', this.$source.prop('name'))
-    this.$target.prop('value', this.$source.val())
+    this.$target.val(this.$source.val())
     this.$source.removeAttr('name')  // Remove from source otherwise form will pass parameter twice.
     this.$element.attr('required', this.$source.attr('required'))
     this.$element.attr('rel', this.$source.attr('rel'))


### PR DESCRIPTION
Context: I'm using jquery ajaxForm to submit a form.  Browser is Chrome on OSX.
I'm setting an initial value of the combobox by setting the attribute selected="selected"
on one of the option nodes.

What I see:
When the form is drawn, the combo box shows the correct preset value.  However
if I submit the form without touching the combo box, it sends an empty value
to the server.  If I click on the combo box and make a selection, it passes a correct
value to the server.

What I expected:
I expected that if the combo box was not touched, the initial value will be passed back, as
it would be with a standard select element.

Observations:
I see that the hidden element that is created is not initialized with the initial value
of the select.  I've attached a commit that copies the initial 
value of the select element to the hidden element.  This solves the problem for me.
