### PR TITLE
Changed parse() method to use option.text() instead of option.html()

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -65,7 +65,7 @@
         }
         map[option.text()] = option.val()
         source.push(option.text())
-        if(option.attr('selected')) selected = option.html()
+        if(option.attr('selected')) selected = option.text()
       })
       this.map = map
       if (selected) {


### PR DESCRIPTION
The parse() method gets the value of the combobox's text field from the selected option using option.html(). When the value contains html characters, the value is "double-escaped" in the text field (e.g. "<" is displayed as "&lt;"). To avoid this, the option's value should be parsed using option.text() and not option.html(), assuming that the <option> tags do not have inner HTML elements.
