### PR TITLE
Add transfering ID from select to text field

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -82,8 +82,10 @@
     this.$target.prop('name', this.$source.prop('name'))
     this.$target.val(this.$source.val())
     this.$source.removeAttr('name')  // Remove from source otherwise form will pass parameter twice.
-    this.$target.prop('id', this.$source.prop('id'))
-    this.$source.removeAttr('id')
+    if(this.options.transferId) {
+      this.$target.prop('id', this.$source.prop('id'))
+      this.$source.removeAttr('id')
+    }
     this.$element.attr('required', this.$source.attr('required'))
     this.$element.attr('rel', this.$source.attr('rel'))
     this.$element.attr('title', this.$source.attr('title'))
@@ -235,6 +237,7 @@
   template: '<div class="combobox-container"><input type="hidden" /><input type="text" autocomplete="off" /><span class="add-on btn dropdown-toggle" data-dropdown="dropdown"><span class="caret"/><span class="combobox-clear"><i class="icon-remove"/></span></span></div>'
   , menu: '<ul class="typeahead typeahead-long dropdown-menu"></ul>'
   , item: '<li><a href="#"></a></li>'
+  , transferId: false
   }
 
   $.fn.combobox.Constructor = Combobox


### PR DESCRIPTION
**Why?**
Given the following:

``` html
<label for="crop_id">Crop</label>
<select id="crop_id">...(options)...</select>
```

As we know, Combobox will hide select and insert text field. It would be nice then, when that text field would be focused after user clicks it's label. It can be achieved by transferring ID from select tag to Combobox text field, like in this pull request :)

So then Combobox will generate:

``` html
<label for="crop_id">Crop</label>
<div class="combobox-containter">
  <input type="text" id="crop_id" />
</div>
<select style="display:none">...(options)...</select>
```

I'm aware that transferring ID is not a small thing, like if somebody would like to use it to get select node, but in this case we could introduce flag option, like "transfer_id", defaults to true.

The idea appeared when I was making integration tests with use of JS (in Capybara) - Capybara is searching for fields using labels for="" reference, so Combobox was failing that test.

What do you think about it?
