### PR TITLE
Added disable and enable functions to combobox.

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -52,6 +52,18 @@
       return combobox
     }
 
+  , disable: function() {
+    this.$element.prop('disabled', true)
+    this.$button.attr('disabled', true)
+    this.$button.off('click')
+  }
+
+  , enable: function() {
+    this.$element.prop('disabled', false)
+    this.$button.attr('disabled', false)
+    this.$button.on('click', $.proxy(this.toggle, this))
+  }
+
   , parse: function () {
       var that = this
         , map = {}
@@ -226,6 +238,7 @@
 
   $.fn.combobox = function ( option ) {
     return this.each(function () {
+      if ($(this).is('input')) return      
       var $this = $(this)
         , data = $this.data('combobox')
         , options = typeof option == 'object' && option


### PR DESCRIPTION
Combobox can now be disabled by calling .combobox('disable'). I basically disabled the input element, removed the click event for the select element and disabled the element as well.

The combobox can be enabled back by calling .combobox('enable').

I noticed that calling the .combobox() function the second time would consider 'input.combobox' as a valid element, so I had to avoid it in the library.

Please let me know if I can improve the code somehow, as this is my first open-source contribution :D
