### PR TITLE
Implemented option for free-form text entry into combo box - see header ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ combobox:
       });
     </script>
 
+Finally, if you need to keep the values on the input of the combobox upon submit (for instance, when you are doing
+validation via an AJAX call), you can pass via the JSON option object the attribute "keeponblur" set to "true":
+
+    <script type="text/javascript">
+      $(document).ready(function(){
+        $('.combobox').combobox({freeform: true, keeponblur: true});
+      });
+    </script>
+
 ## Live Example
 
 http://dl.dropbox.com/u/21368/bootstrap-combobox/index.html

--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -73,7 +73,7 @@
         source.push(option.text())
         if (option.prop('selected')) {
           selected = option.text()
-          selectedValue = option.val()
+          selectedValue = option.val() ? option.val() : option.text()
         }
       })
       this.map = map
@@ -130,6 +130,7 @@
 
   , clearTarget: function () {
     this.$source.val('')
+
     if (!this.options.freeform) {
       this.$target.val('')
     }
@@ -212,18 +213,16 @@
 
       this.$button
         .on('click', $.proxy(this.toggle, this))
-
-
     }
 
   , getdataval: function () {
-      // clear hidden field
-      this.$target.val('').trigger('change')
-
       // get passed-in combobox data
       var val = this.$source.attr('data-value')
 
       if (this.options.freeform) {
+        // clear hidden field
+        this.$target.val('').trigger('change')
+
         if (this.map[val]) {
           this.$element.val(this.map[val])
         }
@@ -232,7 +231,7 @@
         }
       }
 
-      if (val !== '') {
+      if (val !== '' && val !== undefined) {
         this.$source.val(val).trigger('change')
         this.$target.val(val).trigger('change')
       }
@@ -303,6 +302,10 @@
             this.$target.val(this.map[val]).trigger('change')
           }
           else {
+            if (!this.options.keeponblur) {
+              this.$element.val('')
+            }
+
             this.$target.val(this.mapi[val]).trigger('change')
           }
         }

--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -13,7 +13,7 @@
   <script src="vendor/qunit.js"></script>
 
   <!--  plugin sources -->
-  
+
   <script src="../../js/bootstrap-combobox.js"></script>
 
   <!-- unit tests -->

--- a/js/tests/unit/bootstrap-combobox.js
+++ b/js/tests/unit/bootstrap-combobox.js
@@ -37,7 +37,7 @@ $(function () {
         combobox.$menu.remove()
       })
 
-      test("should listen to an button", function () {
+      test("should listen to a button", function () {
         var $select = $('<select />')
           , $button = $select.combobox().data('combobox').$button
         ok($._data($button[0], 'events').click, 'has a click event')
@@ -98,6 +98,26 @@ $(function () {
         combobox.$container.remove()
       })
 
+      test("should show menu when no item is selected and down arrow is pressed", function() {
+        var $select = $('<select><option></option><option>aa</option><option>ab</option><option>ac</option></select>').appendTo('body')
+          , $input = $select.combobox().data('combobox').$element
+          , combobox = $select.data('combobox')
+
+          $input.trigger({
+              type: 'keyup'
+              , keyCode: 40
+          })
+
+          ok(combobox.$menu.is(":visible"), 'menu is visible')
+          equal(combobox.$menu.find('li').length, 3, 'has 3 items in menu')
+          equal(combobox.$menu.find('.active').length, 1, 'one item is active')
+          ok(combobox.$menu.find('li').first().hasClass('active'), 'first item is active')
+
+          combobox.$menu.remove()
+          $select.remove()
+          combobox.$container.remove()
+      })
+
       test("should set next item when down arrow is pressed", function () {
         var $select = $('<select><option></option><option>aa</option><option>ab</option><option>ac</option></select>').appendTo('body')
           , $input = $select.combobox().data('combobox').$element
@@ -138,7 +158,7 @@ $(function () {
           , $input = combobox.$element
           , $source = combobox.$source
           , $target = combobox.$target
-          
+
 
         $input.val('a')
         combobox.lookup()
@@ -237,6 +257,21 @@ $(function () {
         combobox.$menu.remove()
       })
 
+      test("should keep input on blur when value does not exist", function() {
+        var $select = $('<select><option>aa</option></select>')
+          , $input = $select.combobox({keeponblur: true}).data('combobox').$element
+          , combobox = $select.data('combobox')
+
+        $input.val('KEEP ON BLUR')
+        combobox.lookup()
+        $input.trigger('blur')
+
+        equal($input.val(), 'KEEP ON BLUR', 'input value was correctly set')
+        equal($select.val(), 'aa', 'select value was correctly set')
+
+        combobox.$menu.remove()
+      })
+
       test("should set placeholder text on the input if specified text of no value option", function() {
         var $select = $('<select><option value="">Pick One</option><option value="aa">aa</option><option value="ab">ab</option><option value="ac">ac</option></select>')
           , $input = $select.combobox().data('combobox').$element
@@ -295,5 +330,20 @@ $(function () {
         equal($input.attr('title'), 'A title', 'title was correctly set')
 
         combobox.$menu.remove()
+      })
+
+      test("should copy data-value attribute to the input if specified on the select and freeform is set", function() {
+        var $select = $('<select data-value="bb"><option></option><option>aa</option><option selected>ab</option><option>ac</option></select>')
+          , $input = $select.combobox({freeform: true}).data('combobox').$element
+          , $target = $select.combobox({freeform: true}).data('combobox').$target
+          , combobox = $select.data('combobox')
+
+          equal($input.val(), 'bb', 'input value was correctly set')
+          equal($target.val(), 'bb', 'hidden input value was correctly set')
+          equal($select.val(), '', 'select value was correctly set')
+
+          combobox.$menu.remove()
+          $select.remove()
+          combobox.$container.remove()
       })
 })


### PR DESCRIPTION
...comment notes for details.

This is my first time using github, so forgive me if this is wrong or incorrect in some manner...

A little background: I am a web developer for Fender (http://www.fender.com/) and we had a need for a combobox widget; I found your widget and it fit the need almost perfectly, but a means to enter in a freeform text entry (that wasn't in the dropdown) was also needed. A few minor changes, and what you see here is what I came up with.

I won't claim it to be totally correct, but it seems to work; if the "freeform" option is set when the widget is instantiated, my changes are used, otherwise the default is used.

I hope this makes sense; the comments in the header are just there to document this option - it would be preferable, should this change be merged into the main branch that they are stripped and become a part of the documentation of course.

Thank you.
