### PR TITLE
Trigger original element change event after hidden element change

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -98,8 +98,8 @@
   , select: function () {
       var val = this.$menu.find('.active').attr('data-value');
       this.$element.val(this.updater(val)).trigger('change');
-      this.$source.val(this.map[val]).trigger('change');
       this.$target.val(this.map[val]).trigger('change');
+      this.$source.val(this.map[val]).trigger('change');
       this.$container.addClass('combobox-selected');
       this.selected = true;
       return this.hide();


### PR DESCRIPTION
If you want to do something like submit a form automatically the original select element change needs to happen after the new hidden input change. The reason for this is that the name is removed from the select and placed on the hidden input and if you try to submit the form for that input has its value set you  will always get an empty string for that input name. 

In theory this should "Just Work" and should not break anyone. I need this change to use this combobox so it would be great if you can accept it! 

![tumblr_lpq79idwny1qii6tmo1_500](https://f.cloud.github.com/assets/674284/1328834/f096a504-350a-11e3-8552-e22c71974614.gif)
