### PR TITLE
Moved dropdown menu to stay as a child of the `body`.

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -110,12 +110,11 @@
     }
 
   , show: function () {
-      var pos = $.extend({}, this.$element.position(), {
+      var pos = $.extend({}, this.$element.offset(), {
         height: this.$element[0].offsetHeight
       });
 
       this.$menu
-        .insertAfter(this.$element)
         .css({
           top: pos.top + pos.height
         , left: pos.left


### PR DESCRIPTION
This allows it to overlap everything instead of being contained to the widgets parent container.
