### PR TITLE
Add 'combobox-selected' class before triggering change events.

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -97,11 +97,14 @@
 
   , select: function () {
       var val = this.$menu.find('.active').attr('data-value');
-      this.$element.val(this.updater(val)).trigger('change');
-      this.$target.val(this.map[val]).trigger('change');
-      this.$source.val(this.map[val]).trigger('change');
+      this.$element.val(this.updater(val));
+      this.$target.val(this.map[val]);
+      this.$source.val(this.map[val]);
       this.$container.addClass('combobox-selected');
       this.selected = true;
+      this.$element.trigger('change');
+      this.$target.trigger('change');
+      this.$source.trigger('change');
       return this.hide();
     }
 


### PR DESCRIPTION
Allows change event handler to call combobox('toggle') to clear the combobox.
