### PR TITLE
Hide icon-remove when nothing selected + align caret vertically on bootstrap 2

### DIFF
--- a/css/bootstrap-combobox.css
+++ b/css/bootstrap-combobox.css
@@ -11,8 +11,11 @@
 .combobox-selected .caret {
   display: none;
 }
+.combobox-boostrap-2 .caret {
+  margin-top: 8px;
+}
 /* :not doesn't work in IE8 */
-.combobox-container:not(.combobox-selected) .glyphicon-remove {
+.combobox-container:not(.combobox-selected) .glyphicon-remove, .combobox-container:not(.combobox-selected) .icon-remove {
   display: none;
 }
 .typeahead-long {

--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -173,9 +173,9 @@
       return this.render(items.slice(0, this.options.items)).show();
     }
 
-  , template: function() {
+, template: function() {
       if (this.options.bsVersion == '2') {
-        return '<div class="combobox-container"><input type="hidden" /> <div class="input-append"> <input type="text" autocomplete="off" /> <span class="add-on dropdown-toggle" data-dropdown="dropdown"> <span class="caret"/> <i class="icon-remove"/> </span> </div> </div>'
+        return '<div class="combobox-container combobox-boostrap-2"><input type="hidden" /> <div class="input-append"> <input type="text" autocomplete="off" /> <span class="add-on dropdown-toggle" data-dropdown="dropdown"> <span class="caret"/> <i class="icon-remove"/> </span> </div> </div>'
       } else {
         return '<div class="combobox-container"> <input type="hidden" /> <div class="input-group"> <input type="text" autocomplete="off" /> <span class="input-group-addon dropdown-toggle" data-dropdown="dropdown"> <span class="caret" /> <span class="glyphicon glyphicon-remove" /> </span> </div> </div>'
       }

--- a/less/combobox.less
+++ b/less/combobox.less
@@ -14,8 +14,12 @@
   display: none;
 }
 
+.combobox-boostrap-2 .caret {
+  margin-top: 8px;
+}
+
 /* :not doesn't work in IE8 */
-.combobox-container:not(.combobox-selected) .glyphicon-remove {
+.combobox-container:not(.combobox-selected) .glyphicon-remove, .combobox-container:not(.combobox-selected) .icon-remove {
   display: none;
 }
 


### PR DESCRIPTION
When using bootstrap 2 there were some UI bugs:
- "icon-remove" was not hidden when nothing selected
- Caret was not vertically aligned

This should fix those.
