### PR TITLE
Change look/behavior of combobox in an inline form when viewport is less than 768px

### DIFF
--- a/css/bootstrap-combobox.css
+++ b/css/bootstrap-combobox.css
@@ -1,12 +1,14 @@
-.form-search .combobox-container,
-.form-inline .combobox-container {
-  display: inline-block;
-  margin-bottom: 0;
-  vertical-align: top;
-}
-.form-search .combobox-container .input-group-addon,
-.form-inline .combobox-container .input-group-addon {
-  width: auto;
+@media (min-width: 768px) {
+  .form-search .combobox-container,
+  .form-inline .combobox-container {
+    display: inline-block;
+    margin-bottom: 0;
+    vertical-align: top;
+  }
+  .form-search .combobox-container .input-group-addon,
+  .form-inline .combobox-container .input-group-addon {
+    width: auto;
+  }
 }
 .combobox-selected .caret {
   display: none;

--- a/less/combobox.less
+++ b/less/combobox.less
@@ -1,11 +1,13 @@
-.form-search,
-.form-inline {
-  .combobox-container {
-    display: inline-block;
-    margin-bottom: 0;
-    vertical-align: top;
-    .input-group-addon{
-      width: auto;
+@media (min-width: 768px) {
+  .form-search,
+  .form-inline {
+    .combobox-container {
+      display: inline-block;
+      margin-bottom: 0;
+      vertical-align: top;
+      .input-group-addon {
+        width: auto;
+      }
     }
   }
 }


### PR DESCRIPTION
Current Default Look/Behavior
------
Currently, a bootstrap-combobox for the inline form looks as expected on the on the desktop.

![screen shot 2015-01-14 at 9 43 54 pm](https://cloud.githubusercontent.com/assets/6329898/5739231/28a1173a-9c3a-11e4-86e9-339317fe86f7.jpg)

However on screens that are smaller than 768px the inline form bootstrap-combobox does not span the entire width.

![screen shot 2015-01-14 at 9 42 57 pm](https://cloud.githubusercontent.com/assets/6329898/5739249/a2d4bd5e-9c3a-11e4-9822-389fc0a37c20.jpg)

Both images are screenshots from http://bootstrap-combobox-test.herokuapp.com.

This may not look so problematic in the example above. However, when you insert the bootstrap-combobox in an inline form with other bootstrap inputs, the apparent difference in *consistency* becomes a bit more obvious. For example, here is an image of a bootstrap-combobox among a search and month inputs.

When the screen is > 768px:

![screen shot 2015-01-14 at 9 40 22 pm](https://cloud.githubusercontent.com/assets/6329898/5739310/a4fb6a0a-9c3b-11e4-9f81-d2f574de5430.jpg)

When the screen is < 768px:

![screen shot 2015-01-14 at 9 41 52 pm](https://cloud.githubusercontent.com/assets/6329898/5739316/b4daf5ee-9c3b-11e4-93e4-17970710fc01.jpg)

The combobox when the screen is < 768px seems to be out of place.

Proposed Change in Default Look/Behavior
----
I believe the bootstrap-combobox would be more consistent with the bootstrap framework if it spanned the width of the screen for screen's less than 768px. In Bootstrap 3.3.1's forms.less file, the form-inline class has been implemented to only have an effect when the screen is > 768px:

```
// From boostrap-3.3.1/less/forms.less

// Make forms appear inline(-block) by adding the `.form-inline` class. Inline
// forms begin stacked on extra small (mobile) devices and then go inline when
// viewports reach <768px.
//
// Requires wrapping inputs and labels with `.form-group` for proper display of
// default HTML form controls and our custom form controls (e.g., input groups).
//
// Heads up! This is mixin-ed into `.navbar-form` in navbars.less.

.form-inline {

  // Kick in the inline
  @media (min-width: @screen-sm-min) {
    // Inline-block all the things for "inline"
    .form-group {
      display: inline-block;
      margin-bottom: 0;
      vertical-align: middle;
    }

// etc

```

If the less/css file could just wrap a media query around the form-inline class, the default look/behavior of the bootstrap-combobox would be more consistent. The resulting changes for the two examples above will look as follows:

![screen shot 2015-01-14 at 9 43 32 pm](https://cloud.githubusercontent.com/assets/6329898/5739529/d40fb04c-9c3d-11e4-8fa8-50f0517efa85.jpg)

![screen shot 2015-01-14 at 9 40 40 pm](https://cloud.githubusercontent.com/assets/6329898/5739531/dad12cf8-9c3d-11e4-9c0c-ba50b8c38bf4.jpg)