### PR TITLE
Fix keyboard scrolling

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -327,17 +327,34 @@
         case 38: // up arrow
           e.preventDefault();
           this.prev();
+          this.fixMenuScroll();
           break;
 
         case 40: // down arrow
           e.preventDefault();
           this.next();
+          this.fixMenuScroll();
           break;
       }
 
       e.stopPropagation();
     }
-
+  
+  , fixMenuScroll: function(){
+      var active = this.$menu.find('.active');
+      if(active.length){
+    	  var top = active.position().top;
+    	  var bottom = top + active.height();
+    	  var scrollTop = this.$menu.scrollTop();
+    	  var menuHeight = this.$menu.height();
+    	  if(bottom > menuHeight){
+    		  this.$menu.scrollTop(scrollTop + bottom - menuHeight);
+    	  } else if(top < 0){
+    		  this.$menu.scrollTop(scrollTop + top);
+    	  }
+      }
+  }
+  
   , keydown: function (e) {
       this.suppressKeyPressRepeat = ~$.inArray(e.keyCode, [40,38,9,13,27]);
       this.move(e);

--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -339,22 +339,22 @@
 
       e.stopPropagation();
     }
-  
+
   , fixMenuScroll: function(){
       var active = this.$menu.find('.active');
       if(active.length){
-    	  var top = active.position().top;
-    	  var bottom = top + active.height();
-    	  var scrollTop = this.$menu.scrollTop();
-    	  var menuHeight = this.$menu.height();
-    	  if(bottom > menuHeight){
-    		  this.$menu.scrollTop(scrollTop + bottom - menuHeight);
-    	  } else if(top < 0){
-    		  this.$menu.scrollTop(scrollTop + top);
-    	  }
+          var top = active.position().top;
+          var bottom = top + active.height();
+          var scrollTop = this.$menu.scrollTop();
+          var menuHeight = this.$menu.height();
+          if(bottom > menuHeight){
+              this.$menu.scrollTop(scrollTop + bottom - menuHeight);
+          } else if(top < 0){
+              this.$menu.scrollTop(scrollTop + top);
+          }
       }
   }
-  
+
   , keydown: function (e) {
       this.suppressKeyPressRepeat = ~$.inArray(e.keyCode, [40,38,9,13,27]);
       this.move(e);


### PR DESCRIPTION
This fixes issue #154: when moving around the menu with keyboard controls and there are more entries than fit in the menu, the selection would move out of the scroll area.