### PR TITLE
Added option to append a string to the source's ID and set the ID att…

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -97,6 +97,9 @@
 
   , transferAttributes: function() {
     this.options.placeholder = this.$source.attr('data-placeholder') || this.options.placeholder
+    if(this.options.appendId !== "undefined") {
+    	this.$element.attr('id', this.$source.attr('id') + this.options.appendId);	
+    }
     this.$element.attr('placeholder', this.options.placeholder)
     this.$target.prop('name', this.$source.prop('name'))
     this.$target.val(this.$source.val())


### PR DESCRIPTION
In order to support accessibility, specifically associating a label with the rendered combobox, I added an 'appendId' option to the 'options' that if specified, it will use the source's id, append the value of the option, and add the resulting string as the rendered combobox's id.  This allows proper linkage of a label to the combobox via the label's 'for' attribute.