### PR TITLE
Performance improvement for very long list scenarios.

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -254,7 +254,8 @@
           this.hide();
         } else {
           this.clearElement();
-          this.lookup();
+          this.$menu.html(this.sourceElements);
+          this.show();
         }
       }
     }
@@ -282,6 +283,13 @@
 
   , refresh: function () {
     this.source = this.parse();
+    var that = this;
+    this.sourceElements = $(this.source).map(function (i, item) {
+      i = $(that.options.item).attr('data-value', item);
+      i.find('a').html(item);
+      return i[0];
+    })
+    this.$menu.html(this.sourceElements);
     this.options.items = this.source.length;
   }
 
@@ -371,8 +379,17 @@
           if (!this.shown) {return;}
           this.hide();
           break;
-
-        default:
+        
+		case 8:  //backspace
+        case 46: //delete
+          if(!this.$element.val()){
+            this.clearTarget();
+            this.triggerChange();
+            this.clearElement();
+            break;
+          }
+        
+		default:
           this.clearTarget();
           this.lookup();
       }


### PR DESCRIPTION
Creating a separate complete list of all elements which can be displayed
without running a matcher on empty string when the dropdown is to be
pulled down.
Also, backspace and delete button press will trigger any change only if
the string is non empty to ignore unnecessary trigger of functions