### PR TITLE
Added scrollToOption function 

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -330,19 +330,34 @@
         case 38: // up arrow
           e.preventDefault();
           this.prev();
-          this.fixMenuScroll();
+          this.scrollToOption();
           break;
 
         case 40: // down arrow
           e.preventDefault();
           this.next();
-          this.fixMenuScroll();
+          this.scrollToOption();
           break;
       }
 
       e.stopPropagation();
     }
-
+	
+  , scrollToOption: function () {
+	  var option = this.$menu.find('.active');
+      if(option.length){
+        var optionTop = option.offset().top,
+            menuTop = this.$menu.offset().top,
+            windowHeight = $(window).height(),    
+            optionBottom = windowHeight - optionTop - option.outerHeight(true),
+            menuButtom = windowHeight - menuTop - this.$menu.outerHeight(true);
+        if (menuTop > optionTop || menuButtom > optionBottom) {
+          this.$menu.scrollTop(option.offset().top - this.$menu.offset().top + this.$menu.scrollTop());
+        }
+      }
+    }
+	
+	// Not working as expected. Should be replaced by scrollToOption()
   , fixMenuScroll: function(){
       var active = this.$menu.find('.active');
       if(active.length){


### PR DESCRIPTION
The old fixMenuScroll() solution does not work as expected, it often happens that the scroll gets ahead of the actual selection and the selected option is not visible.
The scrollToOption() function fixes that behavior. Used it in one of my projects and hope it will help the community.