### PR TITLE
fixed error with hidden required input fields

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -105,6 +105,7 @@
     this.$target.val(this.$source.val())
     this.$source.removeAttr('name')  // Remove from source otherwise form will pass parameter twice.
     this.$element.attr('required', this.$source.attr('required'))
+	this.$source.removeAttr('required')
     this.$element.attr('rel', this.$source.attr('rel'))
     this.$element.attr('title', this.$source.attr('title'))
     this.$element.attr('class', this.$source.attr('class'))


### PR DESCRIPTION
using the combobox with the required attribute led to an error in the clients console with google chrome, because of the fact that hidden input fields may not be required in a form.
This could be fixed by adding the "novalidate" attribute to the form, though this should not be the way to go. With this commit the combobox is still required, though the hidden select tag won't be. The form still requires the input needed + validation is still up.
(hint: http://stackoverflow.com/a/23215333/5065201)