### PR TITLE
Appending typeahead to container instead of body

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -31,7 +31,7 @@
     this.$element = this.$container.find('input[type=text]');
     this.$target = this.$container.find('input[type=hidden]');
     this.$button = this.$container.find('.dropdown-toggle');
-    this.$menu = $(this.options.menu).appendTo('body');
+    this.$menu = $(this.options.menu).appendTo(this.$container);
     this.matcher = this.options.matcher || this.matcher;
     this.sorter = this.options.sorter || this.sorter;
     this.highlighter = this.options.highlighter || this.highlighter;


### PR DESCRIPTION
Now, when re-rendering as in an Angular or BackboneJS app, ComboBox doesn't leave trash behind like an American tourist in a foreign country.