### PR TITLE
Call #highlight on different el if bsVersion set to 4

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -215,7 +215,8 @@
 
       items = $(items).map(function (i, item) {
         i = $(that.options.item).attr('data-value', item);
-        i.find('a').html(that.highlighter(item));
+        var rootEl = that.options.bsVersion == '4' ? i : i.find('a')
+        rootEl.html(that.highlighter(item));
         return i[0];
       })
 


### PR DESCRIPTION
I propose a small change in `render` function, which would allow `bootstrap-combobox` to conform with Bootstrap 4.

The way to create dropdowns in Bootstrap 4 looks as follows:
```
<div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
    <a class="dropdown-item" href="#">Action</a>
    <a class="dropdown-item" href="#">Another action</a>
    <a class="dropdown-item" href="#">Something else here</a>
  </div>
```

The significant difference is that dropdown items are now not nested in `<li>` elements, so updating combobox defaults like this:
```
$.fn.combobox.defaults = {
    bsVersion: '4',
    menu: '<div class="dropdown-menu"></div>',
    item: '<a class="dropdown-item"></button>'
}
```
is not enough to make it work.