### PR TITLE
Added class so now Bootstrap 4 compatible

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -454,7 +454,7 @@
   $.fn.combobox.defaults = {
     bsVersion: '3'
   , menu: '<ul class="typeahead typeahead-long dropdown-menu"></ul>'
-  , item: '<li><a href="#"></a></li>'
+  , item: '<li><a href="#" class="dropdown-item"></a></li>'
   };
 
   $.fn.combobox.Constructor = Combobox;


### PR DESCRIPTION
I have added the class "dropdown-item" to the menu item links.  With this additional class the dropdown menu now styles correctly on Bootstrap 4.