### PR TITLE
Bugfix to make option appendId work

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -97,7 +97,7 @@
 
   , transferAttributes: function() {
     this.options.placeholder = this.$source.attr('data-placeholder') || this.options.placeholder
-    if(this.options.appendId !== "undefined") {
+    if(typeof this.options.appendId !== "undefined") {
     	this.$element.attr('id', this.$source.attr('id') + this.options.appendId);
     }
     this.$element.attr('placeholder', this.options.placeholder)


### PR DESCRIPTION
this.options.appendId !== "undefined" 
always returns "true". We want to test if option appendId is set, so better replace it with
typeof this.options.appendId !== "undefined"