### PR TITLE
support Bootstrap 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ When activating the plugin, you may include an object containing options for the
  `renderLimit`: The maximum number of suggestions to render on the screen at one time. Useful for dealing with source elements with items.
 
  `clearIfNoMatch`: When true, the combobox will clear its contents when unfocusing if a matching option is not selected. Defaults to true.
+
+ `iconCaret`: Custom icon font class for the caret button of the combobox. This is only effective when using {bsVersion: '4'}. (e.g. 'fas fa-caret-down' when using Font Awesome)
+
+ `iconRemove`: Custom icon font class for the remove button of the combobox. This is only effective when using {bsVersion: '4'}. (e.g. 'fas fa-times' when using Font Awesome)
  
  
 

--- a/css/bootstrap-combobox.css
+++ b/css/bootstrap-combobox.css
@@ -10,11 +10,23 @@
     width: auto;
   }
 }
-.combobox-selected .caret {
+.combobox-container .dropdown-toggle {
+  justify-content: center;
+}
+.combobox-container .dropdown-toggle.custom-icon::after {
+  content: none;
+}
+.combobox-container.combobox-selected .dropdown-toggle::after {
+  content: none;
+}
+.combobox-container .utf-remove::after {
+  content: "\00D7";
+}
+.combobox-container.combobox-selected .pulldown {
   display: none;
 }
 /* :not doesn't work in IE8 */
-.combobox-container:not(.combobox-selected) .glyphicon-remove {
+.combobox-container:not(.combobox-selected) .remove {
   display: none;
 }
 .typeahead-long {

--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -23,7 +23,7 @@
  /* COMBOBOX PUBLIC CLASS DEFINITION
   * ================================ */
 
-  var hasPopper = typeof(Popper) !== 'undefined';
+  var hasPopper = typeof Popper !== 'undefined';
 
   var Combobox = function ( element, options ) {
     this.options = $.extend({}, $.fn.combobox.defaults, options);
@@ -186,18 +186,13 @@
       } else if (this.options.bsVersion == '3') {
         return '<div class="combobox-container"> <input type="hidden" /> <div class="input-group"> <input type="text" autocomplete="off" /> <span class="input-group-addon dropdown-toggle" data-dropdown="dropdown"> <span class="caret pulldown" /> <span class="glyphicon glyphicon-remove remove" /> </span> </div> </div>'
       } else {
-        return `<div class="combobox-container">
-            <input type="hidden" />
-            <div class="input-group">
-              <input type="text" autocomplete="off" />
-              <span class="input-group-append"${hasPopper ? ' data-toggle="dropdown" data-reference="parent"' : ''}>
-                <span class="input-group-text dropdown-toggle${this.options.iconCaret ? ' custom-icon' : ''}">
-                  ${this.options.iconCaret ? `<span class="${this.options.iconCaret} pulldown" />` : ''}
-                  ${this.options.iconRemove ? `<span class="${this.options.iconRemove} remove" />` : '<span class="utf-remove remove" />'}
-                </span>
-              </span>
-            </div>
-          </div>`;
+        return '<div class="combobox-container"> <input type="hidden" /> <div class="input-group"> <input type="text" autocomplete="off" />'
+          + '<span class="input-group-append"' + (hasPopper ? ' data-toggle="dropdown" data-reference="parent"' : '') + '>'
+            + '<span class="input-group-text dropdown-toggle' + (this.options.iconCaret ? ' custom-icon' : '') + '">'
+              + (this.options.iconCaret ? '<span class="' + this.options.iconCaret + ' pulldown" />' : '')
+              + (this.options.iconRemove ? '<span class="' + this.options.iconRemove + ' remove" />' : '<span class="utf-remove remove" />')
+            + '</span>'
+          + '</span> </div> </div>';
       }
     }
 

--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -180,9 +180,22 @@
 
   , template: function() {
       if (this.options.bsVersion == '2') {
-        return '<div class="combobox-container"><input type="hidden" /> <div class="input-append"> <input type="text" autocomplete="off" /> <span class="add-on dropdown-toggle" data-dropdown="dropdown"> <span class="caret"/> <i class="icon-remove"/> </span> </div> </div>'
+        return '<div class="combobox-container"><input type="hidden" /> <div class="input-append"> <input type="text" autocomplete="off" /> <span class="add-on dropdown-toggle" data-dropdown="dropdown"> <span class="caret pulldown" style="vertical-align: middle"/> <i class="icon-remove remove"/> </span> </div> </div>'
+      } else if (this.options.bsVersion == '3') {
+        return '<div class="combobox-container"> <input type="hidden" /> <div class="input-group"> <input type="text" autocomplete="off" /> <span class="input-group-addon dropdown-toggle" data-dropdown="dropdown"> <span class="caret pulldown" /> <span class="glyphicon glyphicon-remove remove" /> </span> </div> </div>'
       } else {
-        return '<div class="combobox-container"> <input type="hidden" /> <div class="input-group"> <input type="text" autocomplete="off" /> <span class="input-group-addon dropdown-toggle" data-dropdown="dropdown"> <span class="caret" /> <span class="glyphicon glyphicon-remove" /> </span> </div> </div>'
+        return `<div class="combobox-container">
+            <input type="hidden" />
+            <div class="input-group">
+              <input type="text" autocomplete="off" />
+              <span class="input-group-append">
+                <span class="input-group-text dropdown-toggle${this.options.iconCaret ? ' custom-icon' : ''}" data-dropdown="dropdown">
+                  ${this.options.iconCaret ? `<span class="${this.options.iconCaret} pulldown" />` : ''}
+                  ${this.options.iconRemove ? `<span class="${this.options.iconRemove} remove" />` : '<span class="utf-remove remove" />'}
+                </span>
+              </span>
+            </div>
+          </div>`;
       }
     }
 
@@ -460,6 +473,8 @@
     bsVersion: '4'
   , menu: '<ul class="typeahead typeahead-long dropdown-menu"></ul>'
   , item: '<li><a href="#" class="dropdown-item"></a></li>'
+  , iconCaret: undefined
+  , iconRemove: undefined
   , clearIfNoMatch: true
   };
 

--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -23,6 +23,8 @@
  /* COMBOBOX PUBLIC CLASS DEFINITION
   * ================================ */
 
+  var hasPopper = typeof(Popper) !== 'undefined';
+
   var Combobox = function ( element, options ) {
     this.options = $.extend({}, $.fn.combobox.defaults, options);
     this.template = this.options.template || this.template
@@ -188,8 +190,8 @@
             <input type="hidden" />
             <div class="input-group">
               <input type="text" autocomplete="off" />
-              <span class="input-group-append">
-                <span class="input-group-text dropdown-toggle${this.options.iconCaret ? ' custom-icon' : ''}" data-dropdown="dropdown">
+              <span class="input-group-append"${hasPopper ? ' data-toggle="dropdown" data-reference="parent"' : ''}>
+                <span class="input-group-text dropdown-toggle${this.options.iconCaret ? ' custom-icon' : ''}">
                   ${this.options.iconCaret ? `<span class="${this.options.iconCaret} pulldown" />` : ''}
                   ${this.options.iconRemove ? `<span class="${this.options.iconRemove} remove" />` : '<span class="utf-remove remove" />'}
                 </span>


### PR DESCRIPTION
Currently how the combobox looks is not good at all with Bootstrap 4, where only caret icon appears on the right to the input, although the functions are fine.

It is because the migration from Bootstrap 3 to 4 and also the migration from Glyphicons are required. Dropdown uses Popper.js, so that bootstrap-combobox should work with it. Dropdown also works without Popper.js, so that I made it also work even without Popper.js.

- Add template for Bootstrap 4.
- Replace Glyphicons class from css.
- Add ability to optionally use other icon fonts when using Bootstrap 4.
- Make it work nicely when using Bootstrap 4 with Popper.js, and even when without Popper.js

I verified it works with the following versions of Bootstrap.
- 4.1.3 ("bootstrap": "^4.1.3").
- 3.3.7 ("bootstrap": "^3.3.7")
- 2.3.2 ("bootstrap-2.3.2": "^1.0.0") with Popper.js 1.14.6
