### PR TITLE
Fix bug when using with Turbolinks

### DIFF
--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -24,6 +24,7 @@
   * ================================ */
 
   var Combobox = function ( element, options ) {
+    if (this.removeIfComboboxed(element)) return;
     this.options = $.extend({}, $.fn.combobox.defaults, options);
     this.template = this.options.template || this.template
     this.$source = $(element);
@@ -68,6 +69,15 @@
       this.disabled = false;
       this.$container.removeClass('combobox-disabled');
     }
+
+    // Remove combobox generated dropdowns from cached page to avoid duplicating dropdowns when navigating back or forward using Turbolinks
+  , removeIfComboboxed: function(element) {
+    let $container = $(element).parents('[data-combobox-generated]');
+    let isPreviousCombobox = $container.length > 0;
+    if (isPreviousCombobox) $container.remove();
+    return isPreviousCombobox;
+  }
+
   , parse: function () {
       var that = this
         , map = {}
@@ -180,9 +190,9 @@
 
   , template: function() {
       if (this.options.bsVersion == '2') {
-        return '<div class="combobox-container"><input type="hidden" /> <div class="input-append"> <input type="text" autocomplete="off" /> <span class="add-on dropdown-toggle" data-dropdown="dropdown"> <span class="caret"/> <i class="icon-remove"/> </span> </div> </div>'
+        return '<div class="combobox-container" data-combobox-generated><input type="hidden" /> <div class="input-append"> <input type="text" autocomplete="off" /> <span class="add-on dropdown-toggle" data-dropdown="dropdown"> <span class="caret"/> <i class="icon-remove"/> </span> </div> </div>'
       } else {
-        return '<div class="combobox-container"> <input type="hidden" /> <div class="input-group"> <input type="text" autocomplete="off" /> <span class="input-group-addon dropdown-toggle" data-dropdown="dropdown"> <span class="caret" /> <span class="glyphicon glyphicon-remove" /> </span> </div> </div>'
+        return '<div class="combobox-container" data-combobox-generated> <input type="hidden" /> <div class="input-group"> <input type="text" autocomplete="off" /> <span class="input-group-addon dropdown-toggle" data-dropdown="dropdown"> <span class="caret" /> <span class="glyphicon glyphicon-remove" /> </span> </div> </div>'
       }
     }
 


### PR DESCRIPTION
When using [Turbolinks](https://github.com/turbolinks/turbolinks) and navigating back or forward in the browser history the plugin is generating extra comboboxes, I think this is because Turbolinks caches the page and then when navigating through the browser history the plugins creates extra comboboxes from the previous generated comboboxes.

For example, this happens when navigating back in history (there should be only one dropdown):

![duplicated-combobox](https://user-images.githubusercontent.com/24409418/52731147-ce5abc00-2f9b-11e9-9285-a711c45db0d1.png)

With this change we ensure to remove from the DOM previous generated comboboxes at the moment the plugin tries to create new comboboxes based on them.